### PR TITLE
Only use WebGL if requested and WebGL support is detected.

### DIFF
--- a/src/OgvJsPlayer.js
+++ b/src/OgvJsPlayer.js
@@ -21,7 +21,14 @@ function OgvJsTimeRanges(ranges) {
 
 function OgvJsPlayer(options) {
 	options = options || {};
-	var useWebGL = !!options.webGL && detectWebGL();
+	var webGLdetected = detectWebGL();
+	var useWebGL = !!options.webGL && webGLdetected;
+	if(!!options.forceWebGL) {
+		useWebGL = true;
+		if(!webGLdetected) {
+			console.log("No support for WebGL detected, but WebGL forced on!");
+		}
+	}
 	
 	var canvas = document.createElement('canvas');
 	var ctx;

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -687,7 +687,7 @@
 				player.durationHint = durationHint;
 			} else if (playerBackend == 'webgl') {
 				player = new OgvJsPlayer({
-					webGL: true
+					forceWebGL: true
 				});
 				player.durationHint = durationHint;
 			} else if (playerBackend == 'flash') {


### PR DESCRIPTION
The check is perhaps useful if one wants to make WebGL rendering the default.
