### PR TITLE
Fix for src being "null" (string) when not set.

### DIFF
--- a/src/js/OGVPlayer.js
+++ b/src/js/OGVPlayer.js
@@ -1407,7 +1407,7 @@ var OGVPlayer = function(options) {
 	 */
 	Object.defineProperty(self, "src", {
 		get: function getSrc() {
-			return '' + self.getAttribute('src');
+			return self.getAttribute('src') || '';
 		},
 		set: function setSrc(val) {
 			self.setAttribute('src', val);


### PR DESCRIPTION
If the attribute src is not yet set, this src property return a string "null".
Because of this, the ogv.js player tries to download a video file called "null".