### PR TITLE
Allow passing custom backend to audio-feeder

### DIFF
--- a/src/js/OGVPlayer.js
+++ b/src/js/OGVPlayer.js
@@ -906,6 +906,10 @@ class OGVPlayer extends OGVJSElement {
 			// Try passing a pre-created output node in?
 			audioOptions.output = options.audioDestination;
 		}
+		if (options.audioBackendConstructor) {
+			// Allow setting a custom backend for audioFeeder
+			audioOptions.backendConstructor = options.audioBackendConstructor;
+		}
 
 		let audioFeeder = this._audioFeeder = new AudioFeeder(audioOptions);
 		audioFeeder.init(this._audioInfo.channels, this._audioInfo.rate);


### PR DESCRIPTION
Requires https://github.com/brion/audio-feeder/pull/34 to be merged to work, but should be safe even without.