### PR TITLE
Fix exports of `ogv-support.js`/`ogv-version.js` + some JS build clean-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,14 +2557,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -10404,9 +10410,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001298",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true
     },
     "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ogv",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ogv",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.16.7"
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3665,6 +3665,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/espree/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
@@ -8204,18 +8216,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -9907,9 +9907,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true
     },
     "acorn-import-assertions": {
@@ -11283,6 +11283,12 @@
         "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -14552,12 +14558,6 @@
         "webpack-sources": "^3.2.2"
       },
       "dependencies": {
-        "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-          "dev": true
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   ],
   "scripts": {
     "prepack": "make -j4 dist",
-    "build": "webpack",
+    "build": "webpack --mode=production",
     "lint": "eslint src/js",
     "test": "make tests && npx static build/tests",
-    "demo": "webpack serve --open-page=build/demo",
-    "start": "webpack serve"
+    "demo": "webpack serve --mode=development --open-page=build/demo",
+    "start": "webpack serve --mode=development"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist/"
   ],
   "scripts": {
-    "prepublish": "make -j4 dist",
+    "prepack": "make -j4 dist",
     "build": "webpack",
     "lint": "eslint src/js",
     "test": "make tests && npx static build/tests",

--- a/src/js/ogv-support.js
+++ b/src/js/ogv-support.js
@@ -7,12 +7,6 @@
 import OGVCompat from './OGVCompat.js';
 const OGVVersion = __OGV_FULL_VERSION__;
 
-if (typeof window === 'object') {
-    // 1.0-compat globals
-    window.OGVCompat = OGVCompat;
-    window.OGVVersion = OGVVersion;
-}
-
 export {
     OGVCompat,
     OGVVersion

--- a/src/js/ogv-version.js
+++ b/src/js/ogv-version.js
@@ -6,9 +6,4 @@
 
 const OGVVersion = __OGV_FULL_VERSION__;
 
-if (typeof window === 'object') {
-    // 1.0-compat globals
-    window.OGVVersion = OGVVersion;
-}
-
 export {OGVVersion};

--- a/src/js/ogv.js
+++ b/src/js/ogv.js
@@ -12,17 +12,6 @@ import OGVPlayer from './OGVPlayer.js';
 import OGVTimeRanges from './OGVTimeRanges.js';
 const OGVVersion = __OGV_FULL_VERSION__;
 
-// Version 1.0's web-facing and test-facing interfaces
-if (typeof window === 'object') {
-	window.OGVCompat = OGVCompat;
-	window.OGVLoader = OGVLoader;
-	window.OGVMediaError = OGVMediaError; // exposed for testing, for now
-	window.OGVMediaType = OGVMediaType;
-	window.OGVTimeRanges = OGVTimeRanges; // exposed for testing, for now
-	window.OGVPlayer = OGVPlayer;
-	window.OGVVersion = OGVVersion;
-}
-
 export {
 	OGVCompat,
 	OGVLoader,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,6 @@ module.exports = [
   {
     // Main entry point! - ES Module
     entry: './src/js/ogv.js',
-    mode: 'production',
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
@@ -114,7 +113,6 @@ module.exports = [
   {
     // Main entry point! - ES5
     entry: './src/js/ogv.js',
-    mode: 'production',
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
@@ -134,7 +132,6 @@ module.exports = [
   {
     // Alt limited entry point for compat testing before loading
     entry: './src/js/ogv-support.js',
-    mode: 'production',
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
@@ -151,7 +148,6 @@ module.exports = [
   {
     // Alt limited entry point for just exposting the version marker string
     entry: './src/js/ogv-version.js',
-    mode: 'production',
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
@@ -168,7 +164,6 @@ module.exports = [
   },
 	{
 	  entry: './src/js/workers/ogv-worker-audio.js',
-    mode: 'production',
 	  output: {
 	    path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
@@ -185,7 +180,6 @@ module.exports = [
 	},
   {
     entry: './src/js/workers/ogv-worker-video.js',
-    mode: 'production',
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,8 +98,10 @@ module.exports = [
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
       filename: 'ogv-es2017.js',
-      libraryTarget: 'umd',
-      library: 'ogvjs'
+      library: {
+        // `library.name` is omitted, since we want exports to be assigned directly to the root object
+        type: 'umd'
+      }
     },
     plugins: plugins,
     module: {
@@ -117,8 +119,10 @@ module.exports = [
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
       filename: 'ogv.js',
-      libraryTarget: 'umd',
-      library: 'ogvjs'
+      library: {
+        // `library.name` is omitted, since we want exports to be assigned directly to the root object
+        type: 'umd'
+      }
     },
     plugins: plugins,
     module: {
@@ -135,7 +139,11 @@ module.exports = [
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
-      filename: 'ogv-support.js'
+      filename: 'ogv-support.js',
+      library: {
+        // `library.name` is omitted, since we want exports to be assigned directly to the root object
+        type: 'umd'
+      }
     },
     plugins: plugins,
     module: {
@@ -151,7 +159,11 @@ module.exports = [
     output: {
       path: path.resolve(__dirname, BUILD_DIR),
       publicPath: publicPath(),
-      filename: 'ogv-version.js'
+      filename: 'ogv-version.js',
+      library: {
+        // `library.name` is omitted, since we want exports to be assigned directly to the root object
+        type: 'umd'
+      }
     },
     plugins: plugins,
     module: {


### PR DESCRIPTION
The main reason for this PR is to fix the issue where the compiled `ogv-support.js` and `ogv-version.js` files don't actually export anything, where you'd expect the `OGVCompat` and `OGVVersion` exports. In fact, these files would only assign those values to the global object.

I've fixed this by specifying the `output.library.type: 'umd'` option for these entries in the webpack config. This will make the exports work as expected in AMD/CommonJS module environments. 

Additionally, by omitting `output.library.name`, the exports will be assigned directly to the `window` object when loaded in a `<script>` tag. Therefore, I've also removed the explicit `window`-assignments from the main three entrypoints.

See also: https://webpack.js.org/configuration/output/#type-umd

---

Other small changes to the JS build:
- Changed `prepublish` script to `prepack`, so `make -j4 dist` only runs before `npm pack`/`npm publish` and NOT for `npm install`. This might require a change in the README. If you disagree with this change, I suggest changing it to `prepare` instead as per https://docs.npmjs.com/cli/v9/using-npm/scripts#prepare-and-prepublish.
- NPM automatically updated `package-lock.json` after `npm install`.
- Updated Browserslist DB, see https://github.com/browserslist/update-db#why-you-need-to-call-it-regularly.
- Webpack `mode` is now specified per-script in `package.json`, allowing for development mode builds while developing.